### PR TITLE
Use batch mode by default

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -32,6 +32,8 @@ jobs:
           bash Miniforge3-Linux-x86_64.sh -b -p $HOME/miniforge
           eval "$(${HOME}/miniforge/bin/conda shell.bash hook)"
           conda install --yes constructor
+          # See https://github.com/conda/constructor/pull/440
+          pip install git+https://github.com/chrisburr/constructor.git@add-batch_mode
       - name: Create installer
         run: |
           eval "$(${HOME}/miniforge/bin/conda shell.bash hook)"

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ These instructions will install the latest release of DIRACOS in a folder named 
 
 ```bash
 curl -LO https://github.com/DIRACGrid/DIRACOS2/releases/latest/download/DIRACOS-Linux-x86_64.sh
-bash DIRACOS-Linux-x86_64.sh -b -p "$PWD/diracos/"
+bash DIRACOS-Linux-x86_64.sh
 ```
 
 It can then be activated in a similar way to version 1 of DIRACOS, by calling ` source "$PWD/diracos/diracosrc"`.

--- a/construct.yaml
+++ b/construct.yaml
@@ -13,6 +13,7 @@ conda_default_channels:
 post_install: create_diracosrc.sh
 keep_pkgs: false
 default_prefix: "${PWD}/diracos"
+batch_mode: true
 
 # Converting packages to be .conda files makes the installer considerably
 # smaller and faster but is computationally expensive.

--- a/scripts/run_basic_tests.sh
+++ b/scripts/run_basic_tests.sh
@@ -5,4 +5,4 @@ IFS=$'\n\t'
 IMAGE_NAME=$1
 DIRACOS_INSTALLER=$2
 
-exec docker run --rm --privileged -v "${PWD}":/diracos-repo "${IMAGE_NAME}" bash -c "bash /diracos-repo/${DIRACOS_INSTALLER} -b -p diracos && source diracos/diracosrc && pytest -v /diracos-repo/tests/test_import.py && bash /diracos-repo/tests/test_cli.sh"
+exec docker run --rm --privileged -v "${PWD}":/diracos-repo "${IMAGE_NAME}" bash -c "bash /diracos-repo/${DIRACOS_INSTALLER} && source diracos/diracosrc && pytest -v /diracos-repo/tests/test_import.py && bash /diracos-repo/tests/test_cli.sh"


### PR DESCRIPTION

BEGINRELEASENOTES

NEW: Batch mode is now the default when installing (https://github.com/conda/constructor/pull/440)

ENDRELEASENOTES
