### PR TITLE
Reset cache of transmuted packages once a week

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -19,13 +19,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - id: get-date
+        run: echo "::set-output name=year-and-week::$(date +"%Y-W%U")"
+        shell: bash
       - name: Keep constructor cache between invocations
         # This is big help to avoid needing to transmuting packages every time
-        id: cache-primes
+        id: cache-transmuted-packages
         uses: actions/cache@v2
         with:
           path: ~/.conda/constructor
-          key: ${{ runner.os }}-constructor
+          key: ${{ runner.os }}-constructor-${{ steps.get-date.outputs.year-and-week }}
       - name: Prepare environment
         run: |
           wget https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-Linux-x86_64.sh


### PR DESCRIPTION
To make the final installer smaller and faster packages are converted from conda's `tar.bz2` format to `.conda` however this is a very CPU intensive operation. As a result a cache is being used to keep the transmuted packages and speed up the CI from 20+ minutes to about 3 minutes. An issue however is that this cache is never reset so it slowly becomes useless over time. This PR now makes it so the current week and year number is included in the cache key so ensure it is reset at least once a week.