### PR TITLE
Remove python-irodsclient and add more packages on aarch64 and ppc64le

### DIFF
--- a/construct.yaml
+++ b/construct.yaml
@@ -47,7 +47,7 @@ specs:
   - apache-libcloud
   - boto3
   - gfal2-util
-  - nordugrid-arc  # [linux64]
+  - nordugrid-arc
   - python-gfal2
   - voms
   # Others

--- a/construct.yaml
+++ b/construct.yaml
@@ -35,7 +35,7 @@ specs:
   - m2crypto >=0.36
   - pyasn1 >0.4.1
   - pyasn1-modules
-  - tornado_m2crypto  # [linux64]
+  - tornado_m2crypto
   # Databases
   - cmreshandler >1.0.0b4
   - elasticsearch-dsl
@@ -71,7 +71,7 @@ specs:
   - six
   - subprocess32
   - suds-jurko >=0.6
-  - tornado *+dirac*  # [linux64]
+  - tornado *+dirac*
   - xmltodict
   - importlib_resources
   # Testing and development

--- a/construct.yaml
+++ b/construct.yaml
@@ -67,7 +67,7 @@ specs:
   - pytz >=2015.7
   - requests >=2.9.1
   - rrdtool
-  - singularity  # [linux64]
+  - singularity
   - six
   - subprocess32
   - suds-jurko >=0.6

--- a/construct.yaml
+++ b/construct.yaml
@@ -49,7 +49,6 @@ specs:
   - gfal2-util
   - nordugrid-arc  # [linux64]
   - python-gfal2
-  - python-irodsclient
   - voms
   # Others
   - diraccfg


### PR DESCRIPTION
BEGINRELEASENOTES

CHANGE: Remove python-irodsclient
CHANGE: The aarch64 and ppc64le installers are now contain the same packages as x86_64

ENDRELEASENOTES
