### PR TITLE
Stop using a fork of conda-constructor

### DIFF
--- a/scripts/environment.yml
+++ b/scripts/environment.yml
@@ -14,6 +14,3 @@ dependencies:
   - uritemplate
   - python-dateutil
   - pytz
-  - pip:
-    # See https://github.com/conda/constructor/pull/440
-    - git+https://github.com/chrisburr/constructor.git@add-batch_mode


### PR DESCRIPTION
Now a release has been made we can stop using my fork.

Closes #20 