### PR TITLE
Release SQLAlchemy constraint

### DIFF
--- a/construct.yaml
+++ b/construct.yaml
@@ -43,8 +43,7 @@ specs:
   - mysql-client
   # Earlier versions of mysqlclient were build with older MySQL versions
   - mysqlclient >=2.0.3
-  # Freeze until all problems with 1.4 are solved
-  - sqlalchemy ==1.3.*
+  - sqlalchemy
   - stomp.py =4.1.23
   # Middleware
   - apache-libcloud


### PR DESCRIPTION
BEGINRELEASENOTES

CHANGE: Release constraint on SQLALchemy versions

ENDRELEASENOTES
