### PR TITLE
fixing elasticsearch-py to <7.14

### DIFF
--- a/construct.yaml
+++ b/construct.yaml
@@ -39,6 +39,7 @@ specs:
   - tornado_m2crypto
   # Databases
   - cmreshandler >1.0.0b4
+  - elasticsearch <7.14
   - elasticsearch-dsl
   - mysql-client
   # Earlier versions of mysqlclient were build with older MySQL versions


### PR DESCRIPTION
All in https://aws.amazon.com/blogs/opensource/keeping-clients-of-opensearch-and-elasticsearch-compatible-with-open-source/

Already done in DIRACGrid/DIRAC#5322 and https://github.com/DIRACGrid/DIRACOS/pull/188

BEGINRELEASENOTES

FIX: fixing elasticsearch-py to <7.14

ENDRELEASENOTES
