### PR TITLE
 Exclude packages when building MacOS distribution

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -22,7 +22,7 @@ jobs:
         shell: bash -l {0}
     strategy:
       matrix:
-        target_arch: ["linux-64", "linux-aarch64", "linux-ppc64le"]
+        target_arch: ["linux-64", "linux-aarch64", "linux-ppc64le", "osx-arm64", "osx-64"]
     steps:
       - uses: actions/checkout@v2
       - id: get-date

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -22,7 +22,7 @@ jobs:
         shell: bash -l {0}
     strategy:
       matrix:
-        target_arch: ["linux-64", "linux-aarch64", "linux-ppc64le", "osx-arm64", "osx-64"]
+        target_arch: ["linux-64", "linux-aarch64", "linux-ppc64le", "osx-64"]
     steps:
       - uses: actions/checkout@v2
       - id: get-date

--- a/construct.yaml
+++ b/construct.yaml
@@ -36,7 +36,7 @@ specs:
   - m2crypto >=0.36,<0.38
   - pyasn1 >0.4.1
   - pyasn1-modules
-  - tornado_m2crypto
+  - tornado_m2crypto  # [not osx]
   # Databases
   - cmreshandler >1.0.0b4
   - elasticsearch <7.14
@@ -51,7 +51,7 @@ specs:
   - boto3
   - gfal2-util
   - htcondor-utils  # [linux64]
-  - nordugrid-arc
+  - nordugrid-arc  # [not osx]
   - python-gfal2
   - python-htcondor  # [linux64]
   - voms
@@ -62,7 +62,7 @@ specs:
   - git
   - gitpython >=2.1.0
   - matplotlib-base
-  - myproxy
+  - myproxy  # [not osx]
   - numpy
   - openssh
   - pexpect >=4.0.1
@@ -73,11 +73,11 @@ specs:
   - pytz >=2015.7
   - requests >=2.9.1
   - rrdtool
-  - singularity >=3.7
+  - singularity >=3.7  # [not osx]
   - six
   - subprocess32
   - suds-jurko >=0.6
-  - tornado *+dirac*
+  - tornado *+dirac*  # [not osx]
   - xmltodict
   - importlib_resources
   # Testing and development

--- a/scripts/make_release.py
+++ b/scripts/make_release.py
@@ -20,6 +20,8 @@ PLATFORM_MAPPING = {
     "linux-64": "Linux-x86_64",
     "linux-aarch64": "Linux-aarch64",
     "linux-ppc64le": "Linux-ppc64le",
+    "osx-64": "Darwin-x86_64",
+    "osx-arm64": "Darwin-arm64"
 }
 logging.basicConfig(level=logging.INFO)
 
@@ -67,7 +69,7 @@ def main(
 
     # Download the artifacts
     installers = {}
-    for platform in ["linux-64", "linux-aarch64", "linux-ppc64le"]:
+    for platform in PLATFORM_MAPPING:
         logging.info(f"Getting installer for {platform}")
         if artifacts_dir:
             assert dry_run

--- a/scripts/make_release.py
+++ b/scripts/make_release.py
@@ -20,8 +20,7 @@ PLATFORM_MAPPING = {
     "linux-64": "Linux-x86_64",
     "linux-aarch64": "Linux-aarch64",
     "linux-ppc64le": "Linux-ppc64le",
-    "osx-64": "Darwin-x86_64",
-    "osx-arm64": "Darwin-arm64"
+    "osx-64": "Darwin-x86_64"
 }
 logging.basicConfig(level=logging.INFO)
 


### PR DESCRIPTION

BEGINRELEASENOTES

FIX: excludes several packages from building the MacOS distribution
CHANGE: add MacOS platforms for the building process

ENDRELEASENOTES