### PR TITLE
Run tests against rel-v7r3 in CI

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -141,7 +141,7 @@ jobs:
       matrix:
         dirac-branch:
           - rel-v7r2
-          - integration
+          - rel-v7r3
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -173,6 +173,7 @@ jobs:
       fail-fast: false
       matrix:
         dirac-branch:
+          - rel-v7r3
           - integration
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION

BEGINRELEASENOTES

NEW: Integration tests are additionally ran against 7.3.x series releases

ENDRELEASENOTES
