### PR TITLE
fix: remove the constraint on htcondor

### DIFF
--- a/construct.yaml
+++ b/construct.yaml
@@ -51,12 +51,10 @@ specs:
   - boto3
   - gfal2-util
   - fts3 >=0.0.0.1.dev2
+  - htcondor-utils  # [linux64]
   - nordugrid-arc  # [not osx]
   - python-gfal2
-  # Constrain the version for now until using 9.1.3+ is understood
-  # See emails about "HTCondor submission error" from the hackathon on 18/11/2021
-  - htcondor-utils 9.1.2 # [linux64]
-  - python-htcondor 9.1.2 # [linux64]
+  - python-htcondor  # [linux64]
   - rucio-clients
   - voms
   # Others


### PR DESCRIPTION
From `htcondor 9.1.3`:
https://htcondor.readthedocs.io/en/v9_1/version-history/development-release-series-91.html#version-9-1-3

_"GSI is no longer in the list of default authentication methods. To use GSI, you must enable it by setting one or more of the SEC\_\<access-level\>\_AUTHENTICATION\_METHODS configuration parameters."_

Adding `export _condor_SEC_DEFAULT_AUTHENTICATION_METHODS="GSI,TOKEN,SCITOKEN,SSL,FS"` to `/opt/dirac/bashrc` would enable GSI for `htcondor > 9.1.2`.


BEGINRELEASENOTES
FIX: remove the constraint on htcondor
ENDRELEASENOTES
