### PR TITLE
Add: opensearch python packages to environment

### DIFF
--- a/construct.yaml
+++ b/construct.yaml
@@ -42,7 +42,7 @@ specs:
   # elasticsearch packages can be removed once DIRAC 7.3 is not used anymore - replaced by opensearch
   - elasticsearch <7.14
   - elasticsearch-dsl
-  - opensearchpy
+  - opensearch-py
   - opensearch-dsl
   - mysql-client
   # Earlier versions of mysqlclient were build with older MySQL versions

--- a/construct.yaml
+++ b/construct.yaml
@@ -41,6 +41,8 @@ specs:
   - cmreshandler >1.0.0b4
   - elasticsearch <7.14
   - elasticsearch-dsl
+  - opensearchpy
+  - opensearch-dsl
   - mysql-client
   # Earlier versions of mysqlclient were build with older MySQL versions
   - mysqlclient >=2.0.3

--- a/construct.yaml
+++ b/construct.yaml
@@ -39,6 +39,7 @@ specs:
   - tornado_m2crypto  # [not osx]
   # Databases
   - cmreshandler >1.0.0b4
+  # elasticsearch packages can be removed once DIRAC 7.3 is not used anymore - replaced by opensearch
   - elasticsearch <7.14
   - elasticsearch-dsl
   - opensearchpy


### PR DESCRIPTION
The package `opensearch-dsl` is not available yet with conda forge: compiled a [pull request](https://github.com/conda-forge/staged-recipes/pull/17180) to add the package.

BEGINRELEASENOTES

NEW:  added OpenSearch packages to environment for DIRACOS2

ENDRELEASENOTES
