### PR TITLE
Use fts3, micromamba and include version in the install prefix

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -45,6 +45,7 @@ jobs:
         run: |
           CONDA_SUBDIR=${{ matrix.target_arch }} mamba create --name constructor-${{ matrix.target_arch }} micromamba
           CONDA_STANDALONE_PATH="$(conda info --envs | grep constructor-${{ matrix.target_arch }} | sed -E 's@([^ ]+ +)@@g')/bin/micromamba"
+          pip install git+http://github.com/chrisburr/constructor.git@diracos2-patches
           constructor . --platform="${{ matrix.target_arch }}" --conda-exe="${CONDA_STANDALONE_PATH}"
       - name: Upload installer
         uses: actions/upload-artifact@v2

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -43,8 +43,8 @@ jobs:
           use-mamba: true
       - name: Create installer
         run: |
-          CONDA_SUBDIR=${{ matrix.target_arch }} mamba create --name constructor-${{ matrix.target_arch }} conda-standalone
-          CONDA_STANDALONE_PATH="$(conda info --envs | grep constructor-${{ matrix.target_arch }} | sed -E 's@([^ ]+ +)@@g')/standalone_conda/conda.exe"
+          CONDA_SUBDIR=${{ matrix.target_arch }} mamba create --name constructor-${{ matrix.target_arch }} micromamba
+          CONDA_STANDALONE_PATH="$(conda info --envs | grep constructor-${{ matrix.target_arch }} | sed -E 's@([^ ]+ +)@@g')/bin/micromamba"
           constructor . --platform="${{ matrix.target_arch }}" --conda-exe="${CONDA_STANDALONE_PATH}"
       - name: Upload installer
         uses: actions/upload-artifact@v2

--- a/construct.yaml
+++ b/construct.yaml
@@ -55,7 +55,7 @@ specs:
   - apache-libcloud
   - boto3
   - gfal2-util
-  - fts3 >=0.0.0.1.dev2
+  - fts3 >=3.12
   - nordugrid-arc  # [not osx]
   - python-gfal2
   # Constrain the version for now until using 9.1.3+ is understood

--- a/construct.yaml
+++ b/construct.yaml
@@ -6,6 +6,8 @@ version: 2.16a1
 channels:
   - diracgrid
   - conda-forge
+
+write_condarc: true
 conda_default_channels:
   - diracgrid
   - conda-forge

--- a/create_diracosrc.sh
+++ b/create_diracosrc.sh
@@ -48,6 +48,8 @@
     echo ''
 } > "$PREFIX/diracosrc"
 
+echo "DIRACOS2 $INSTALLER_VER" > "$PREFIX/.diracos_version"
+
 # Workaround for the incorrect etc directory in v7r2
 ln -s "$PREFIX/etc" "$PREFIX/lib/python3.9/site-packages/etc"
 

--- a/scripts/environment.yml
+++ b/scripts/environment.yml
@@ -8,6 +8,7 @@ dependencies:
   - pip
   # Constructor itself
   - constructor
+  - libmambapy
   # For creating release notes and releases
   - packaging
   - requests

--- a/scripts/make_release.py
+++ b/scripts/make_release.py
@@ -94,11 +94,11 @@ def main(
             logging.info(
                 f"Releasing {this_version} next version will be {next_version}"
             )
-        # There should be once instance of the version string in the header and
-        # the rest should be "DIRACOS $VER". Check this is the case.
+        # There should be one instance of the version string in the header, one
+        # to set $INSTALLER_VER and the rest should be "DIRACOS $VER".
         assert (
             header.count(installer_metadata["VER"])
-            == header.count(f"DIRACOS {installer_metadata['VER']}") + 1
+            == header.count(f"DIRACOS {installer_metadata['VER']}") + 2
         )
         # Update the version in the installer to be the requested one
         header = header.replace(installer_metadata["VER"], this_version)


### PR DESCRIPTION
BEGINRELEASENOTES

NEW: DIRACOS2 version can be found in `$DIRAC/.diracos_version`
CHANGE: User micromamba instead of conda-standalone
CHANGE: Use official fts3 release now that it finally supports Python 3

ENDRELEASENOTES
