### PR TITLE
Use conda-standalone instead of micromamba

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -43,8 +43,8 @@ jobs:
           use-mamba: true
       - name: Create installer
         run: |
-          CONDA_SUBDIR=${{ matrix.target_arch }} mamba create --name constructor-${{ matrix.target_arch }} micromamba
-          CONDA_STANDALONE_PATH="$(conda info --envs | grep constructor-${{ matrix.target_arch }} | sed -E 's@([^ ]+ +)@@g')/bin/micromamba"
+          CONDA_SUBDIR=${{ matrix.target_arch }} mamba create --name constructor-${{ matrix.target_arch }} conda-standalone
+          CONDA_STANDALONE_PATH="$(conda info --envs | grep constructor-${{ matrix.target_arch }} | sed -E 's@([^ ]+ +)@@g')/standalone_conda/conda.exe"
           pip install git+http://github.com/chrisburr/constructor.git@diracos2-patches
           constructor . --platform="${{ matrix.target_arch }}" --conda-exe="${CONDA_STANDALONE_PATH}"
       - name: Upload installer


### PR DESCRIPTION
Reverting ee1b6a0b4b183ddd474c150450835ed138645301 while this issue is understood: https://github.com/DIRACGrid/DIRAC/issues/5886.


BEGINRELEASENOTES

CHANGE: Use conda-standalone instead of micromamba

ENDRELEASENOTES
