### PR TITLE
Ensure arc.common and _arc can be imported

### DIFF
--- a/tests/test_import.py
+++ b/tests/test_import.py
@@ -36,6 +36,9 @@ parametrize = pytest.mark.parametrize
 
 moduleNames = [
     "arc",
+    # arc/__init__.py supresses errors
+    "arc.common",
+    "_arc",
     "argparse",
     "array",
     "ast",


### PR DESCRIPTION
This is actually fixed by https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/pull/343 but I'm updating the test to prevent it from happening again.

BEGINRELEASENOTES

FIX: Correct dependencies of arc to prevent import errors with arc.common

ENDRELEASENOTES