### PR TITLE
fix: added CONDOR related settings

### DIFF
--- a/construct.yaml
+++ b/construct.yaml
@@ -64,10 +64,8 @@ specs:
   - fts3 >=3.12
   - nordugrid-arc >=6.15.1  # [not osx]
   - python-gfal2 >=1.11.0
-  # Constrain the version for now until using 9.1.3+ is understood
-  # See emails about "HTCondor submission error" from the hackathon on 18/11/2021
-  - htcondor-utils =9.0 # [linux64]
-  - python-htcondor =9.0 # [linux64]
+  - htcondor-utils >=9.12,<10
+  - python-htcondor >=9.12,<10
   - rucio-clients >=1.28.2
   - voms
   # Others

--- a/create_diracosrc.sh
+++ b/create_diracosrc.sh
@@ -51,6 +51,8 @@
     echo 'if ! checkDir "${X509_VOMSES:-}" ; then'
     echo "  export X509_VOMSES='${PREFIX}/etc/grid-security/vomses'"
     echo 'fi'
+    echo '# Add HTCondorCE related settings: limit authentication methods'
+    echo 'export _CONDOR_SEC_CLIENT_AUTHENTICATION_METHODS=GSI,SCITOKENS'
     echo ''
 } > "$PREFIX/diracosrc"
 


### PR DESCRIPTION
Added _CONDOR_SEC_CLIENT_AUTHENTICATION_METHODS env variable set to support only GSI and SCITOKENS. Other methods will not be tried out to safe time as they are useless in our context anyway. This should also enable GSI for condor versions > 9.0. See #60 that should be merged together with this PR.  

BEGINRELEASENOTES

NEW: diracosrc - added CONDOR environment for using GSI and SCITOKENS auth methods

ENDRELEASENOTES
