### PR TITLE
Set conda virtual packages correctly and add basic macOS tests

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -49,7 +49,7 @@ jobs:
           if [ "${{ matrix.target_arch }}" = osx-64 ]; then
               export CONDA_OVERRIDE_OSX=10.12
           fi
-          constructor . --platform="${{ matrix.target_arch }}" --conda-exe="${CONDA_STANDALONE_PATH}"
+          CONDA_SUBDIR=${{ matrix.target_arch }} constructor . --platform="${{ matrix.target_arch }}" --conda-exe="${CONDA_STANDALONE_PATH}"
       - name: Upload installer
         uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -46,6 +46,9 @@ jobs:
           CONDA_SUBDIR=${{ matrix.target_arch }} mamba create --name constructor-${{ matrix.target_arch }} 'micromamba>=0.22'
           CONDA_STANDALONE_PATH="$(conda info --envs | grep constructor-${{ matrix.target_arch }} | sed -E 's@([^ ]+ +)@@g')/bin/micromamba"
           pip install git+http://github.com/conda/constructor.git@3.3.1
+          if [ "${{ matrix.target_arch }}" = osx-64 ]; then
+              export CONDA_OVERRIDE_OSX=10.12
+          fi
           constructor . --platform="${{ matrix.target_arch }}" --conda-exe="${CONDA_STANDALONE_PATH}"
       - name: Upload installer
         uses: actions/upload-artifact@v2

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -48,6 +48,8 @@ jobs:
           pip install git+http://github.com/conda/constructor.git@3.3.1
           if [ "${{ matrix.target_arch }}" = osx-64 ]; then
               export CONDA_OVERRIDE_OSX=10.12
+          elif [ "${{ matrix.target_arch }}" = linux-64 ]; then
+              export CONDA_OVERRIDE_GLIBC=2.17
           fi
           CONDA_SUBDIR=${{ matrix.target_arch }} constructor . --platform="${{ matrix.target_arch }}" --conda-exe="${CONDA_STANDALONE_PATH}"
       - name: Upload installer

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -132,6 +132,29 @@ jobs:
       - name: Run tests
         run: scripts/run_basic_tests.sh ${{ matrix.docker-image }} DIRACOS-*.sh
 
+  macos-tests:
+    name: macOS tests
+    if: github.repository == 'DIRACGrid/DIRACOS2'
+    needs: build-installer
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macos-11, macos-12]
+    steps:
+      - uses: actions/checkout@v2
+      - name: Download installer
+        uses: actions/download-artifact@v2
+        with:
+          name: installer-osx-64
+      - name: Run tests
+        run: |
+           bash DIRACOS-*.sh
+           set -u
+           source diracos/diracosrc
+           pip install DIRAC
+
+
   integration-tests-client-only:
     name: Integration tests (Py2 server)
     if: github.repository == 'DIRACGrid/DIRACOS2'


### PR DESCRIPTION
no ipython for macos?
cf. https://github.com/andresailer/InstallDiracTests/actions/runs/3343409709/jobs/5536598429#step:3:260

~~I hope this is the proper fix?~~

BEGINRELEASENOTES

FIX: Fix ipython for macOS
NEW: CI add checks for macOS installers

ENDRELEASENOTES
