### PR TITLE
Add workaround for importlib_metadata

### DIFF
--- a/construct.yaml
+++ b/construct.yaml
@@ -101,6 +101,8 @@ specs:
   - tornado *+dirac*  # [not osx]
   - xmltodict
   - importlib_resources
+  # Temporary workaround until we have releases with https://github.com/DIRACGrid/DIRAC/pull/6458
+  - importlib_metadata <5.0.0
   # Testing and development
   - bat
   - docutils


### PR DESCRIPTION
BEGINRELEASENOTES

FIX: Use importlib_metadata<5 until DIRAC is updated

ENDRELEASENOTES

See https://github.com/DIRACGrid/DIRAC/pull/6458