### PR TITLE
Use OpenSSL 3.0.x

### DIFF
--- a/construct.yaml
+++ b/construct.yaml
@@ -49,9 +49,7 @@ specs:
   - elasticsearch-dsl
   - opensearch-py
   - opensearch-dsl
-  # FIXME: We need to pin MySQL as 8.0.28 dropped support for TLS v1.0 and v1.1
-  # In principle MySQL v5.7.10 supports TLSv1.2 but it wasn't enabled in LHCb at least
-  - mysql-client =8.0.27
+  - mysql-client
   # Earlier versions of mysqlclient were build with older MySQL versions
   - mysqlclient >=2.0.3
   - sqlalchemy >=1.4.36
@@ -62,8 +60,6 @@ specs:
   - gfal2 >=2.20.5
   - gfal2-util >=1.7.1
   - fts3 >=3.12
-  # Workaround for buggy 6.16.0 and 6.16.1 builds
-  - nordugrid-arc 6.15.1  # [not osx]
   - nordugrid-arc >=6.15.1  # [not osx]
   - python-gfal2 >=1.11.0
   # Constrain the version for now until using 9.1.3+ is understood

--- a/construct.yaml
+++ b/construct.yaml
@@ -32,15 +32,13 @@ ignore_duplicate_files: true
 # selects an older version to avoid conflicts. This is particularly prone to
 # happening when an old version has incorrect version pins
 specs:
-  # Workaround for https://github.com/conda-forge/micromamba-feedstock/issues/100
-  - micromamba 0.27.0=2 # [osx]
   - micromamba >=0.22.0
   - python 3.9.*
   - pip
+  - openssl >=3
   # Security
   - certifi
-  # M2crypto is buggy from 0.38 https://gitlab.com/m2crypto/m2crypto/-/issues/298
-  - m2crypto >=0.36,<0.38
+  - m2crypto >=0.38
   - pyasn1 >0.4.1
   - pyasn1-modules
   - tornado_m2crypto  # [not osx]

--- a/tests/test_import.py
+++ b/tests/test_import.py
@@ -232,7 +232,7 @@ def test_arc():
     arc.ComputingServiceRetriever
     arc.Endpoint
     arc.Job
-    arc.JobDescription_Parse
+    arc.JobDescription.Parse
     arc.JobDescriptionList
     arc.JobList
     arc.JobSupervisor


### PR DESCRIPTION
BEGINRELEASENOTES

CHANGE: Use OpenSSL 3.0.0 
CHANGE: Use latest mysql client. This will break the use of TLS with servers older than MySQL v5.7.10+ (MariaDB 5.5.41+/MariaDB 10.0.15+). See https://github.com/DIRACGrid/DIRACOS2/pull/95.
CHANGE: Use latest arc client libs

ENDRELEASENOTES
