### PR TITLE
Remove rel-v7r2 from CI

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -169,7 +169,6 @@ jobs:
       fail-fast: false
       matrix:
         dirac-branch:
-          - rel-v7r2
           - rel-v7r3
     steps:
       - uses: actions/checkout@v2

--- a/scripts/environment.yml
+++ b/scripts/environment.yml
@@ -9,6 +9,8 @@ dependencies:
   # Constructor itself
   - constructor
   - libmambapy
+  # Workaround for https://github.com/conda/conda/issues/12219
+  - conda 22.9.0
   # For creating release notes and releases
   - packaging
   - requests


### PR DESCRIPTION

BEGINRELEASENOTES

CHANGE: Stop testing against DIRAC v7r2

ENDRELEASENOTES
