### PR TITLE
Remove v7r2 compatibility workaround

### DIFF
--- a/create_diracosrc.sh
+++ b/create_diracosrc.sh
@@ -60,9 +60,6 @@
 
 echo "DIRACOS2 $INSTALLER_VER" > "$PREFIX/.diracos_version"
 
-# Workaround for the incorrect etc directory in v7r2
-ln -s "$PREFIX/etc" "$PREFIX/lib/python3.11/site-packages/etc"
-
 # Print further install instructions
 echo ""
 echo "DIRACOS has been installed sucessfully in $PREFIX"

--- a/create_diracosrc.sh
+++ b/create_diracosrc.sh
@@ -61,7 +61,7 @@
 echo "DIRACOS2 $INSTALLER_VER" > "$PREFIX/.diracos_version"
 
 # Workaround for the incorrect etc directory in v7r2
-ln -s "$PREFIX/etc" "$PREFIX/lib/python3.9/site-packages/etc"
+ln -s "$PREFIX/etc" "$PREFIX/lib/python3.11/site-packages/etc"
 
 # Print further install instructions
 echo ""


### PR DESCRIPTION
Closes https://github.com/DIRACGrid/DIRACOS2/issues/110

BEGINRELEASENOTES

FIX: Remove v7r2 compatibility workaround.

ENDRELEASENOTES
