### PR TITLE
Workaround for if PS1 is not exported

### DIFF
--- a/create_diracosrc.sh
+++ b/create_diracosrc.sh
@@ -12,7 +12,7 @@
     echo ''
     echo '# Initialise the conda environment in a way which ignores other conda installations'
     echo 'unset CONDA_SHLVL'
-    echo 'eval "$(${DIRACOS}/bin/micromamba shell hook activate -s bash)"'
+    echo 'eval "$(PS1="${PS1:-}" ${DIRACOS}/bin/micromamba shell hook activate -s bash)"'
     echo 'micromamba activate "$DIRACOS"'
     echo ''
     echo '# Silence python warnings'


### PR DESCRIPTION
This matches with what micromamba does internally: https://github.com/mamba-org/mamba/blob/c926198af82a6796c67ae5eee89d903556286588/libmamba/data/micromamba.sh#L20

Closes #109

BEGINRELEASENOTES

FIX: Workaround for if PS1 is not exported

ENDRELEASENOTES
