### PR TITLE
Require importlib_resources <6

### DIFF
--- a/construct.yaml
+++ b/construct.yaml
@@ -98,7 +98,7 @@ specs:
   - suds-jurko-compat
   - tornado *+dirac*
   - xmltodict
-  - importlib_resources
+  - importlib_resources <6
   # Temporary workaround until we have releases with https://github.com/DIRACGrid/DIRAC/pull/6458
   - importlib_metadata <5.0.0
   # Testing and development


### PR DESCRIPTION
For reverting see https://github.com/python/importlib_resources/blob/66ea2dc7eb12b1be2322b7ad002cefb12d364dff/importlib_resources/_legacy.py