### PR TITLE
Require apptainer >=1.2

### DIFF
--- a/construct.yaml
+++ b/construct.yaml
@@ -89,7 +89,6 @@ specs:
   - pytz >=2015.7
   - requests >=2.9.1
   - rrdtool  # [not (osx and arm64)]
-  - singularity >=3.7  # [not osx]
   - apptainer >=1.2  # [not osx]
   - six
   - subprocess32

--- a/construct.yaml
+++ b/construct.yaml
@@ -90,7 +90,7 @@ specs:
   - requests >=2.9.1
   - rrdtool  # [not (osx and arm64)]
   - singularity >=3.7  # [not osx]
-  - apptainer  # [not osx]
+  - apptainer >=1.2  # [not osx]
   - six
   - subprocess32
   - suds >=1.0


### PR DESCRIPTION
BEGINRELEASENOTES

CHANGE: singularity is now provided by apptainer

ENDRELEASENOTES
