### PR TITLE
Force libxml2 2.11.6 to avoid https://its.cern.ch/jira/browse/DMC-1401

### DIFF
--- a/construct.yaml
+++ b/construct.yaml
@@ -113,6 +113,8 @@ specs:
   - authlib >=1.0.0,<1.2.1
   - pyjwt
   - dominate
+  # HACK: Avoid https://its.cern.ch/jira/browse/DMC-1401
+  - libxml2 =2.11.6
   # Probably not needed
   - lz4
   - python-xxhash


### PR DESCRIPTION

BEGINRELEASENOTES

CHANGE: Force libxml2 2.11.6 to avoid https://its.cern.ch/jira/browse/DMC-1401

ENDRELEASENOTES
