### PR TITLE
Revert "Require m2cryto<0.40.0"

### DIFF
--- a/construct.yaml
+++ b/construct.yaml
@@ -39,8 +39,7 @@ specs:
   - openssl >=3
   # Security
   - certifi
-  # https://github.com/DIRACGrid/DIRAC/pull/7568
-  - m2crypto >=0.38,<0.40.0
+  - m2crypto >=0.38
   - pyasn1 >0.4.1
   - pyasn1-modules
   - tornado_m2crypto


### PR DESCRIPTION
This reverts commit 6a1835f232df908d5c372373e23e2921245096c1.



BEGINRELEASENOTES

NEW/CHANGE/FIX: explanation

ENDRELEASENOTES
