### PR TITLE
Use patched apptainer build

### DIFF
--- a/construct.yaml
+++ b/construct.yaml
@@ -4,6 +4,7 @@ name: DIRACOS
 version: 2.38a1
 
 channels:
+  - diracgrid/label/apptainer-2166
   - diracgrid
   - conda-forge
 
@@ -91,7 +92,10 @@ specs:
   - pytz >=2015.7
   - requests >=2.9.1
   - rrdtool  # [not (osx and arm64)]
-  - apptainer >=1.2  # [not osx]
+  # Use a custom build of apptainer to workaround:
+  #  * https://github.com/apptainer/apptainer/issues/2166
+  #  * https://github.com/apptainer/apptainer/issues/2167
+  - apptainer 1.3.0 *_734000  # [not osx]
   - six
   - subprocess32
   - suds >=1.0


### PR DESCRIPTION

BEGINRELEASENOTES

FIX: Workaround apptainer issues on 2nd generation AMD EPYC CPUs with EL9-like kernels

ENDRELEASENOTES
