### PR TITLE
Use apptainer 1.3.6 and remove htcondor/git constraint

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -46,7 +46,7 @@ jobs:
           CONDA_STANDALONE_PATH="$(conda info --envs | grep constructor-${{ matrix.target_arch }} | sed -E 's@([^ ]+ +)@@g')/bin/micromamba"
           pip install git+http://github.com/conda/constructor.git@3.3.1
           if [ "${{ matrix.target_arch }}" = osx-64 ]; then
-              export CONDA_OVERRIDE_OSX=10.13
+              export CONDA_OVERRIDE_OSX=11.0
           elif [ "${{ matrix.target_arch }}" = linux-64 ]; then
               export CONDA_OVERRIDE_GLIBC=2.17
           fi

--- a/construct.yaml
+++ b/construct.yaml
@@ -62,10 +62,8 @@ specs:
   - fts3 >=3.12
   - nordugrid-arc >=6.15.1  # [not osx]
   - python-gfal2 >=1.11.0
-  # Constrain the version for now until using 9.1.3+ is understood
-  # See emails about "HTCondor submission error" from the hackathon on 18/11/2021
-  - htcondor-utils =9.0 # [linux]
-  - python-htcondor =9.0 # [linux]
+  - htcondor-utils >=24.2 # [linux]
+  - python-htcondor >=24.2 # [linux]
   - rucio-clients >=1.28.2
   - voms >=2.1.0rc3
   # Others

--- a/construct.yaml
+++ b/construct.yaml
@@ -51,6 +51,7 @@ specs:
   # They can't actually be removed yet as DIRAC stil has it in the dependencies
   - elasticsearch <7.14
   - elasticsearch-dsl
+  - numpy <2  # elasticsearch<7.14 needs numpy 1.x, remove this constraint when elasticsearch is removed
   # Earlier versions of mysqlclient were build with older MySQL versions
   - mysqlclient >=2.0.3,<2.1
   - sqlalchemy >=1.4.36
@@ -62,10 +63,10 @@ specs:
   - gfal2-util >=1.7.1
   - fts3 >=3.12
   - nordugrid-arc >=6.21  # [not osx]
-  - python-gfal2 >=1.11.0
+  - python-gfal2 >=1.13.0
   - htcondor-utils >=24.2 # [linux]
   - python-htcondor >=24.2 # [linux]
-  - rucio-clients >=1.28.2
+  - rucio-clients >=36.0.0
   - voms >=2.1.0rc3
   # Others
   - cachetools

--- a/construct.yaml
+++ b/construct.yaml
@@ -4,7 +4,6 @@ name: DIRACOS
 version: 2.47a1
 
 channels:
-  - diracgrid/label/apptainer-2166
   - diracgrid
   - conda-forge
 
@@ -94,7 +93,7 @@ specs:
   - pytz >=2015.7
   - requests >=2.9.1
   - rrdtool  # [not (osx and arm64)]
-  - apptainer  # [not osx]
+  - apptainer >=1.3.6  # [not osx]
   - six
   - subprocess32
   - suds >=1.0

--- a/construct.yaml
+++ b/construct.yaml
@@ -47,6 +47,10 @@ specs:
   - opensearch-py
   - opensearch-dsl
   - mysql-client
+  # elasticsearch packages can be removed once DIRAC 7.3 is not used anymore - replaced by opensearch
+  # They can't actually be removed yet as DIRAC stil has it in the dependencies
+  - elasticsearch <7.14
+  - elasticsearch-dsl
   # Earlier versions of mysqlclient were build with older MySQL versions
   - mysqlclient >=2.0.3,<2.1
   - sqlalchemy >=1.4.36

--- a/construct.yaml
+++ b/construct.yaml
@@ -44,9 +44,6 @@ specs:
   - tornado_m2crypto
   # Databases
   - cmreshandler >1.0.0b4
-  # elasticsearch packages can be removed once DIRAC 7.3 is not used anymore - replaced by opensearch
-  - elasticsearch <7.14
-  - elasticsearch-dsl
   - opensearch-py
   - opensearch-dsl
   - mysql-client
@@ -60,7 +57,7 @@ specs:
   - gfal2 >=2.20.5
   - gfal2-util >=1.7.1
   - fts3 >=3.12
-  #  - nordugrid-arc >=6.21  # [not osx]
+  - nordugrid-arc >=6.21  # [not osx]
   - python-gfal2 >=1.11.0
   - htcondor-utils >=24.2 # [linux]
   - python-htcondor >=24.2 # [linux]

--- a/construct.yaml
+++ b/construct.yaml
@@ -60,7 +60,7 @@ specs:
   - gfal2 >=2.20.5
   - gfal2-util >=1.7.1
   - fts3 >=3.12
-  - nordugrid-arc >=6.15.1  # [not osx]
+  #  - nordugrid-arc >=6.21  # [not osx]
   - python-gfal2 >=1.11.0
   - htcondor-utils >=24.2 # [linux]
   - python-htcondor >=24.2 # [linux]
@@ -73,9 +73,7 @@ specs:
   - db12 >=1.0.4
   - diraccfg >=0.2.2
   - future
-  # Pin the git version to avoid this bug
-  # https://lore.kernel.org/git/20240529102307.GF1098944@coredump.intra.peff.net/T/#t
-  - git <=2.45.0
+  - git >=2.46
   - gitpython >=2.1.0
   - git-lfs
   - matplotlib-base


### PR DESCRIPTION
BEGINRELEASENOTES

CHANGE: Update to latest apptainer (1.3.6)
CHANGE: Remove htcondor 9.0.x constraint
CHANGE: macOS 11.0+ is now required for x86_64 machines

ENDRELEASENOTES

Closes #128 
