### PR TITLE
Add nodejs to dependencies in construct.yaml

### DIFF
--- a/construct.yaml
+++ b/construct.yaml
@@ -74,6 +74,7 @@ specs:
   - cachetools
   - celery >=5.2.6
   - cwltool
+  - nodejs
   - db12 >=1.0.4
   - diraccfg >=0.2.2
   - fabric


### PR DESCRIPTION
Needed for javascript substitution features in CWL workflows. Found this missing dependency while testing in certification...
```
ERROR I'm sorry, I couldn't load this CWL file, try again with --debug for more information.
The error was: NodeJSEngine requires Node.js engine to evaluate and validate Javascript expressions, but couldn't find it.  Tried nodejs, node, docker run node:alpine
Workflow failed with exit code 1 after 0:00:00
```

BEGINRELEASENOTES

NEW: Add nodejs to dependencies in construct.yaml

ENDRELEASENOTES
