### PR TITLE
Add rel-v9r0 to build matrix in workflow

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -183,6 +183,7 @@ jobs:
       matrix:
         dirac-branch:
           - rel-v8r0
+          - rel-v9r0
           - integration
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION

BEGINRELEASENOTES

NEW: Add rel-v9r0 to build matrix in workflow

ENDRELEASENOTES
